### PR TITLE
Remove unavailable items from `depends` field of library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=Allows your Arduino to control an OpenMV Cam over Serial (UART), I2C, 
 category=Communication
 url=https://github.com/openmv/openmv-arduino-rpc
 architectures=*
-depends=CAN,SoftwareSerial,SPI,Wire
+depends=CAN
 includes=openmvrpc.h


### PR DESCRIPTION
The `depends` field of [the library.properties metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) specifies the dependencies that should be installed along with
the library by the [Arduino Library Manager](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager).

This field must contain only the names of libraries that are available for installation via Library Manager.

The presence of any items which are not in Library Manager causes installation of the library to fail:

- [Arduino IDE 1.x](https://github.com/arduino/Arduino): "`no protocol:`" error
- [Arduino IDE 2.x](https://github.com/arduino/arduino-ide): fails silently ([`arduino/arduino-ide#621`](https://github.com/arduino/arduino-ide/issues/621))
- [Arduino CLI](https://arduino.github.io/arduino-cli/latest/): "`No valid dependencies solution found`" error

The removed dependencies are ["platform bundled libraries"](https://arduino.github.io/arduino-cli/latest/platform-specification/#platform-bundled-libraries), which are included with the installation of each Arduino boards platform, and thus are managed by [Arduino Boards Manager](https://docs.arduino.cc/learn/starting-guide/cores), not Library Manager. For this reason, there is no reason for these items to be listed in the depends field.

---

Originally reported at https://github.com/arduino/arduino-lint/issues/336