### PR TITLE
Fix i2c interface for esp32

### DIFF
--- a/src/openmvrpc.cpp
+++ b/src/openmvrpc.cpp
@@ -763,8 +763,6 @@ bool rpc_i2c##name##_master::get_bytes(uint8_t *buff, size_t size, unsigned long
 { \
     (void) timeout; \
     bool ok = true; \
-    port.begin(); \
-    port.setClock(__rate); \
 \
     for (size_t i = 0; i < size; i += 32) { \
         size_t size_remaining = size - i; \
@@ -775,7 +773,6 @@ bool rpc_i2c##name##_master::get_bytes(uint8_t *buff, size_t size, unsigned long
         for (size_t j = 0; j < request_size; j++) buff[i+j] = port.read(); \
     } \
 \
-    port.end(); \
     if (ok) ok = ok && (!_same(buff, size)); \
     if (!ok) delay(_get_short_timeout); \
     return ok; \

--- a/src/openmvrpc.h
+++ b/src/openmvrpc.h
@@ -257,17 +257,21 @@ private:
 class rpc_i2c##name##_master : public rpc_master \
 { \
 public: \
-    rpc_i2c##name##_master(uint8_t slave_addr=0x12, uint32_t rate=100000) : rpc_master(), __slave_addr(slave_addr), __rate(rate) {} \
+    rpc_i2c##name##_master(uint8_t slave_addr=0x12, uint32_t rate=0UL) : rpc_master(), __sda_pin(-1), __scl_pin(-1), __slave_addr(slave_addr), __rate(rate) {} \
+    rpc_i2c##name##_master(int sda, int scl, uint8_t slave_addr=0x12, uint32_t rate=0UL) : rpc_master(), __sda_pin(sda), __scl_pin(scl), __slave_addr(slave_addr), __rate(rate) {} \
     ~rpc_i2c##name##_master() {} \
     virtual void _flush() override; \
     virtual bool get_bytes(uint8_t *buff, size_t size, unsigned long timeout) override; \
     virtual bool put_bytes(uint8_t *data, size_t size, unsigned long timeout) override; \
+    virtual void begin() override { port.begin(__sda_pin, __scl_pin, __rate);} \
     void set_slave_addr(uint8_t slave_addr) { __slave_addr = slave_addr; } \
     uint8_t get_slave_addr() { return __slave_addr; } \
 protected: \
     virtual uint32_t _stream_writer_queue_depth_max() override { return 1; } \
 private: \
     uint8_t __slave_addr; \
+    int __sda_pin; \
+    int __scl_pin; \
     uint32_t __rate; \
     rpc_i2c##name##_master(const rpc_i2c##name##_master &); \
 };
@@ -318,16 +322,20 @@ private: \
 class rpc_i2c##name##_slave : public rpc_slave \
 { \
 public: \
-    rpc_i2c##name##_slave(uint8_t slave_addr=0x12) : rpc_slave(), __slave_addr(slave_addr) {} \
+    rpc_i2c##name##_slave(uint8_t slave_addr=0x12) : rpc_slave(), __sda_pin(-1), __scl_pin(-1), __rate(0UL), __slave_addr(slave_addr) {} \
+    rpc_i2c##name##_slave(int sda, int scl, uint8_t slave_addr=0x12, uint32_t rate=0UL) : rpc_slave(), __sda_pin(sda), __scl_pin(scl), __slave_addr(slave_addr), __rate(rate) {} \
     ~rpc_i2c##name##_slave() {} \
     virtual void _flush() override; \
     virtual bool get_bytes(uint8_t *buff, size_t size, unsigned long timeout) override; \
     virtual bool put_bytes(uint8_t *data, size_t size, unsigned long timeout) override; \
-    virtual void begin() override { port.begin(__slave_addr); port.onReceive(onReceiveHandler); port.onRequest(onRequestHandler); } \
+    virtual void begin() override { port.begin(__slave_addr, __sda_pin, __scl_pin, __rate); port.onReceive(onReceiveHandler); port.onRequest(onRequestHandler); } \
 protected: \
     virtual uint32_t _stream_writer_queue_depth_max() override { return 1; } \
 private: \
     uint8_t __slave_addr; \
+    int __sda_pin; \
+    int __scl_pin; \
+    uint32_t __rate; \
     static volatile uint8_t *__bytes_buff; \
     static volatile int __bytes_size; \
     static void onReceiveHandler(int numBytes); \


### PR DESCRIPTION
RPC requests via I²C were extremely unreliable (basically not working at all) on ESP32 due to timing issues. The controllers would quickly go out of sync and no requests were completed.

* Implemented state machine for I²C  to keep master/slave in sync and properly abort failed requests.
* Fixed several potential deadlocks in I²C sequence implementation
* Added OPENMVRPC_NO_CAN flag as option to disable CAN during build since it failed to build with the latest Frameworks due to changed interfaces (maybe someone with CAN experience can look into this issue)
* Introduced fixed frame size RPC_I2C_FRAME_SIZE, because the I²C master can not read the actual available buffer size
* Made the I²C interface initialization in the library optional, so it can be controlled by the user and used with any IO pins on ESP32

Since I needed to modify the constructors, this is a breaking change regarding I²C support of openmv-arduino-rpc.

Tested with ESP32S3 as master and ESP32C3 as slave. Needs testing with different hardware like Atmega 328, AtTiny or software I²C

Note:
There is also a bug in the implementation of the Espressif I²C slave on ESP32, that can cause it to permanently send garbage data if the send buffer runs empty. This is unrelated to openmv-arduino-rpc but will cause problems due to the frequent requests if ESP32 is used in slave mode.
More info and how to fix it here:
```
I²C slave on ESP32 needs patched esp32-hal-i2c-slave.c:

  https://github.com/f0x52/arduino-esp32/commit/e94b5f3f686fbcac0db28960fef9910c52ad71b4

  due to
  https://github.com/espressif/arduino-esp32/issues/12367
```